### PR TITLE
Change temporary-files dependency to cl-fad

### DIFF
--- a/clpython.asd
+++ b/clpython.asd
@@ -69,7 +69,7 @@
 
 (asdf:defsystem :clpython.runtime
     :description "Python runtime environment"
-    :depends-on (:clpython.basic :closer-mop #+ecl :cl-custom-hash-table :temporary-file)
+    :depends-on (:clpython.basic :closer-mop #+ecl :cl-custom-hash-table :cl-fad)
     :components ((:module "runtime"
                           :serial t
                           :components ((:file "rsetup"       )

--- a/runtime/import.lisp
+++ b/runtime/import.lisp
@@ -81,7 +81,7 @@ When FILENAME-ITEMS is (:A :B :C) result could look like #p'/tmp/clpython-A.B.C-
 Might signal TEMPORARY-FILE:CANNOT-CREATE-TEMPORARY-FILE"
   (whereas ((file-name (gethash key *temp-file-map*)))
            (return-from get-temporary-file file-name))
-  (let ((file-stream (temporary-file:open-temporary :template (format nil "TEMPORARY-FILES:~{~A~^-~}-%" filename-items)
+  (let ((file-stream (cl-fad:open-temporary :template (format nil "TEMPORARY-FILES:~{~A~^-~}-%" filename-items)
 						    :direction :output)))
     (prog1 (setf (gethash key *temp-file-map*) (pathname file-stream))
       (close file-stream))))


### PR DESCRIPTION
temporary-files has been deprecated and Hans Heubner is instructing everyone to use cl-fad, which has temporary-files functionality merged into it. This is necessary because cl-fad is maintained and there have been bugfixes to the temporary-files portion since the merge.
