### PR TITLE
Added more grammar support for import statements

### DIFF
--- a/parser/grammar.lisp
+++ b/parser/grammar.lisp
@@ -352,7 +352,11 @@ Value should be a (weak) EQ hash table: (make-weak-key-hash-table :test 'eq).")
 (p import-from-2 :or
    (([*]) $1)
    ((import-as-name comma--import-as-name*) (cons $1 $2))
-   (([(] import-as-name comma--import-as-name* [)]) (cons $2 $3)))
+   (([(] import-as-name--comma+ [)]) $2))
+
+(gp import-as-name--comma+)
+(p import-as-name--comma (import-as-name) $1)
+(p import-as-name--comma (import-as-name [,]) $1)
 
 (gp comma--import-as-name+)
 (p comma--import-as-name ([,] import-as-name) $2)

--- a/test/parser-test.lisp
+++ b/test/parser-test.lisp
@@ -85,7 +85,20 @@
                                                     (invoke-restart (find-restart 'continue)))))
                       (ps s t))
                     `([literal-expr] :number ,(expt 10 n-expt)))))
-    
+
+    ;; import tests
+    (test-equal '(clpython.ast.node:|import-from-stmt|
+                  (clpython.user::|sys|)
+                  ((clpython.user::|path|
+                    NIL)))
+                (ps "from sys import path" t))
+
+    (test-equal '(clpython.ast.node:|import-from-stmt|
+                  (clpython.user::|sys|)
+                  ((clpython.user::|path|
+                    NIL)))
+                (ps "from sys import (path,)" t))
+
     ;; suffix operations
     (test-equal '([attributeref-expr]
 		  ([call-expr]


### PR DESCRIPTION
Hey,

I have been playing around with the grammar for cl-python trying to get to more compatable with the python 2.7.5 grammar.  This is an extension of the existing import grammar that will allow trailing commas.

``` python
from sys import (path, argv,)
```

I have been having some problems getting the test cases to re-compile as expected.  I seem to have to quickload the whole clpython.test to actually get correct results after i have had one failed run.  Otherewise it seems to report the same failure over and over.

Thanks,
Russell
