### PR TITLE
Do not derive pathname of module source

### DIFF
--- a/compiler/compiler.lisp
+++ b/compiler/compiler.lisp
@@ -1629,7 +1629,7 @@ LOCALS shares share tail structure with input arg locals."
                         :current-module-name ,*current-module-name*
                         :defun-wrappers ',(mapcar #'second defun-wrappers)
                         :source ,(when *compile-file-truename*
-                                   (slurp-file (derive-pathname *compile-file-truename*)))
+                                       (slurp-file *compile-file-truename*))
                         :source-func ',module-function-name
                         :compiler-id ,*clpython-compiler-version-id*
                         :is-compiled ,(not (null *compile-file-truename*))))


### PR DESCRIPTION
In reference to issue https://github.com/metawilm/cl-python/issues/1, I was still unable to load python files with mixed case on SBCL.  `CLPYTHON:PARSE` works fine on the mixed-case pathname and just calls `SLURP-FILE` on the provided pathname.  I can then call `CLPYTHON:RUN-PYTHON-AST` on the parsed AST.

However, giving the pathname to `CLPYTHON:RUN` would result in an additional call to `SLURP-FILE` during macroexpansion of `[MODULE-STMT]`.  In `[MODULE-STMT]`, the pathname is reinterpreted through `DERIVE-PATHNAME`, which on SBCL alters the provided case.  Removing the call to `DERIVE-PATHNAME` in `[MODULE-STMT]` appears to workaround this issue.
