### PR TITLE
Cannot import CL packages under recent SBCL

### DIFF
--- a/runtime/import.lisp
+++ b/runtime/import.lisp
@@ -68,7 +68,7 @@ In particular, asdf-binary-locations is used if available.")
                   (asdf-path (when *use-asdf-fasl-locations*
                                (ignore-errors
                                 (let ((path (car (asdf:output-files
-                                                  (make-instance 'asdf:compile-op)
+                                                  (asdf:make-operation 'asdf:compile-op)
                                                   (make-instance 'asdf:cl-source-file
                                                     :parent (asdf:find-system :clpython)
                                                     :pathname bin-path)))))


### PR DESCRIPTION
The following file cannot be loaded with `clpython:run` on recent versions of SBCL:

    import CL
    CL.PRINT("FOO")

Tested as failing on 1.4.13 and likely starting with the ASDF update in 1.4.2.  Here is the backtrace:

    ImportError: Loading of module `CL' was aborted. Binary: /tmp/user/1000/clpython-cl-fasl-p6tnmpa2Imported by: /home/ntd/git/tmkit/test.py

    1: ((FLET CLPYTHON::LOG-ABORT :IN CLPYTHON::PY-IMPORT) T)
    2: ((FLET "CLEANUP-FUN-54" :IN CLPYTHON::PY-IMPORT)) [cleanup]
    3: (CLPYTHON::PY-IMPORT (CLPYTHON.USER::CL) :WITHIN-MOD-PATH #P"/home/ntd/git/tmkit/test.py" :WITHIN-MOD-NAME "__main__")
    4: (CLPYTHON::|python-module __main__|)
    5: (CLPYTHON.USER::|{__main__[0] "import CL" #4138581656636548740}| #<HASH-TABLE :TEST EQ :COUNT 2 {100343ACE3}>)
    6: ((FLET CLPYTHON::RUN-TOP-LEVEL-FORMS :IN CLPYTHON::MODULE-INIT) #<HASH-TABLE :TEST EQ :COUNT 2 {100343ACE3}>)
    7: ((FLET CLPYTHON:RUN :IN CLPYTHON:RUN-PYTHON-AST))


The issue appears to arise in `CLPYTHON::COMPILED-FILE-NAME` with the call to `(make-instance 'asdf:compile-op)`.  On newer SBCL, this throws the following error:

    OPERATION instances must only be created through MAKE-OPERATION.

Replacing `cl:make-instance` with `asdf:make-operation` does not throw
the error in `COMPILED-FILE-NAME` and the above CL import works on
SBCL 1.4.13 and 1.3.14
