### PR TITLE
Unfix ECL

### DIFF
--- a/runtime/metaclass.lisp
+++ b/runtime/metaclass.lisp
@@ -12,8 +12,12 @@
 ;;; Class hierarchy
 
 (defmacro maybe-eval-always (&body body)
-  ;; ECL needs to see the VALIDATE-SUPERCLASS methods
-  #+(or ecl lispworks)
+  #+ecl
+  ;; ECL may need to see the VALIDATE-SUPERCLASS methods.
+  (if (<= ext:+ecl-version-number+ 160103)
+      `(eval-when (compile load eval) ,@body)
+      `(progn ,@body))
+  #+lispworks
   `(eval-when (compile load eval) ,@body)
   #-(or ecl lispworks)
   `(progn ,@body))


### PR DESCRIPTION
Upcoming ECL release will have this problem solved (and clpython does
not load with this fix present, because class is not available at
compile time).